### PR TITLE
Use the C name for FFI function definitions

### DIFF
--- a/core.lisp
+++ b/core.lisp
@@ -46,10 +46,10 @@
       (return-from wayland-event-dispatcher ret))))
 
 
-(defcfun (wl-proxy-add-dispatcher :library libwayland-client) :int
+(defcfun ("wl_proxy_add_dispatcher" :library libwayland-client) :int
   (proxy :pointer) (dispatcher :pointer) (implementation :pointer) (data :pointer))
 
-(defcfun (wl-proxy-destroy :library libwayland-client) :void
+(defcfun ("wl_proxy_destroy" :library libwayland-client) :void
   (proxy :pointer))
 
 (defun set-proxy-pointer (proxy pointer &key (install-dispatcher t))
@@ -144,9 +144,9 @@
     (setf (slot-value proxy 'version)
           (min version (foreign-slot-value (wayland-interface proxy) '(:struct wayland-interface) 'version)))))
 
-(defcfun (wl-proxy-marshal-array :library libwayland-client) :void
+(defcfun ("wl_proxy_marshal_array" :library libwayland-client) :void
   (proxy :pointer) (opcode :uint32) (arguments (:pointer (:union wayland-argument))))
 
-(defcfun (wl-proxy-marshal-array-constructor-versioned :library libwayland-client) :pointer
+(defcfun ("wl_proxy_marshal_array_constructor_versioned" :library libwayland-client) :pointer
   (proxy :pointer) (opcode :uint32) (arguments (:pointer (:union wayland-argument)))
   (interface :pointer) (version :uint32))


### PR DESCRIPTION
When I try to compile `main`, I receive these errors:
```
; in: DEFCFUN (WL-PROXY-ADD-DISPATCHER :LIBRARY LIBWAYLAND-CLIENT)
;     (CFFI:DEFCFUN (COM.ANDREWSOUTAR.CL-WAYLAND-CLIENT/CORE::WL-PROXY-ADD-DISPATCHER
;                    :LIBRARY
;                    COM.ANDREWSOUTAR.CL-WAYLAND-CLIENT/CORE:LIBWAYLAND-CLIENT)
;         :INT
;       (COM.ANDREWSOUTAR.CL-WAYLAND-CLIENT/CORE::PROXY :POINTER)
;       (COM.ANDREWSOUTAR.CL-WAYLAND-CLIENT/CORE::DISPATCHER :POINTER)
;       (COM.ANDREWSOUTAR.CL-WAYLAND-CLIENT/CORE::IMPLEMENTATION :POINTER)
;       (COM.ANDREWSOUTAR.CL-WAYLAND-CLIENT/CORE:DATA :POINTER))
; 
; caught ERROR:
;   (during macroexpansion of (DEFCFUN (WL-PROXY-ADD-DISPATCHER :LIBRARY ...) ...))
;   The value of CFFI::SPEC is (WL-PROXY-ADD-DISPATCHER :LIBRARY LIBWAYLAND-CLIENT), which is not of type (AND SYMBOL (NOT NULL)).

; in: DEFCFUN (WL-PROXY-DESTROY :LIBRARY LIBWAYLAND-CLIENT)
;     (CFFI:DEFCFUN (COM.ANDREWSOUTAR.CL-WAYLAND-CLIENT/CORE::WL-PROXY-DESTROY
;                    :LIBRARY
;                    COM.ANDREWSOUTAR.CL-WAYLAND-CLIENT/CORE:LIBWAYLAND-CLIENT)
;         :VOID
;       (COM.ANDREWSOUTAR.CL-WAYLAND-CLIENT/CORE::PROXY :POINTER))
; 
; caught ERROR:
;   (during macroexpansion of (DEFCFUN (WL-PROXY-DESTROY :LIBRARY ...) ...))
;   The value of CFFI::SPEC is (WL-PROXY-DESTROY :LIBRARY LIBWAYLAND-CLIENT), which is not of type (AND SYMBOL (NOT NULL)).
.
; in: DEFCFUN (WL-PROXY-MARSHAL-ARRAY :LIBRARY LIBWAYLAND-CLIENT)
;     (CFFI:DEFCFUN (COM.ANDREWSOUTAR.CL-WAYLAND-CLIENT/CORE:WL-PROXY-MARSHAL-ARRAY
;                    :LIBRARY
;                    COM.ANDREWSOUTAR.CL-WAYLAND-CLIENT/CORE:LIBWAYLAND-CLIENT)
;         :VOID
;       (COM.ANDREWSOUTAR.CL-WAYLAND-CLIENT/CORE::PROXY :POINTER)
;       (COM.ANDREWSOUTAR.CL-WAYLAND-CLIENT/CORE::OPCODE :UINT32)
;       (COM.ANDREWSOUTAR.CL-WAYLAND-CLIENT/CORE::ARGUMENTS
;        (:POINTER
;         (:UNION COM.ANDREWSOUTAR.CL-WAYLAND-CLIENT/CORE:WAYLAND-ARGUMENT))))
; 
; caught ERROR:
;   (during macroexpansion of (DEFCFUN (WL-PROXY-MARSHAL-ARRAY :LIBRARY ...) ...))
;   The value of CFFI::SPEC is (WL-PROXY-MARSHAL-ARRAY :LIBRARY LIBWAYLAND-CLIENT), which is not of type (AND SYMBOL (NOT NULL)).

; in:
;      DEFCFUN (WL-PROXY-MARSHAL-ARRAY-CONSTRUCTOR-VERSIONED :LIBRARY LIBWAYLAND-CLIENT)
;     (CFFI:DEFCFUN (COM.ANDREWSOUTAR.CL-WAYLAND-CLIENT/CORE:WL-PROXY-MARSHAL-ARRAY-CONSTRUCTOR-VERSIONED
;                    :LIBRARY
;                    COM.ANDREWSOUTAR.CL-WAYLAND-CLIENT/CORE:LIBWAYLAND-CLIENT)
;         :POINTER
;       (COM.ANDREWSOUTAR.CL-WAYLAND-CLIENT/CORE::PROXY :POINTER)
;       (COM.ANDREWSOUTAR.CL-WAYLAND-CLIENT/CORE::OPCODE :UINT32)
;       (COM.ANDREWSOUTAR.CL-WAYLAND-CLIENT/CORE::ARGUMENTS
;        (:POINTER
;         (:UNION COM.ANDREWSOUTAR.CL-WAYLAND-CLIENT/CORE:WAYLAND-ARGUMENT)))
;       (COM.ANDREWSOUTAR.CL-WAYLAND-CLIENT/CORE::INTERFACE :POINTER)
;       (COM.ANDREWSOUTAR.CL-WAYLAND-CLIENT/CORE:VERSION :UINT32))
; 
; caught ERROR:
;   (during macroexpansion of (DEFCFUN (WL-PROXY-MARSHAL-ARRAY-CONSTRUCTOR-VERSIONED :LIBRARY ...) ...))
;   The value of CFFI::SPEC is (WL-PROXY-MARSHAL-ARRAY-CONSTRUCTOR-VERSIONED :LIBRARY LIBWAYLAND-CLIENT), which is not of type (AND SYMBOL (NOT NULL)).
```
Proposed fix:
1. It seems to be necessary when using `:library` style definitions
2. CFFI will automatically translate to hypenated name in the Lisp interface