### PR TITLE
Proposed feature: customizable spec path search through `$XDG_DATA_DIRS`

### DIFF
--- a/generator.lisp
+++ b/generator.lisp
@@ -2,7 +2,8 @@
   (:nicknames #:com.andrewsoutar.cl-wayland-client.generator/generator)
   (:use #:cl #:alexandria #:asdf #:com.andrewsoutar.asdf-generated-system)
   (:use #:com.andrewsoutar.cl-wayland-client/utils #:com.andrewsoutar.cl-wayland-client/codegen)
-  (:import-from #:uiop #:ensure-package #:define-package #:subpathname #:with-staging-pathname)
+  (:import-from #:uiop #:ensure-package #:define-package #:subpathname #:with-staging-pathname
+                #:xdg-data-pathname)
   (:import-from #:cxml-dom)
   (:export #:protocol-system))
 (cl:in-package #:com.andrewsoutar.cl-wayland-client.generator/generator)
@@ -133,8 +134,11 @@
 (defclass protocol-system (generated-system) ())
 
 (defun wayland-xml-name (subname)
-  (list (subpathname (if (equal subname "wayland") "/usr/share/wayland/" "/usr/share/wayland-protocols/")
-                     subname :type "xml")))
+  (let ((subname-directory (if (string= subname "wayland")
+                               "wayland/"
+                               "wayland-protocols/")))
+    (list (xdg-data-pathname
+           (subpathname subname-directory subname :type "xml")))))
 
 (defmethod generated-system-dependencies append ((s protocol-system) subname)
   (unless (equal subname "wayland") (list (concatenate 'string (component-name s) "/wayland"))))


### PR DESCRIPTION
This depends on PR #1. I couldn't find a good way to show the diff across repos.

Proposed feature: allow users to customize path where the generator looks for the wayland protocol specs
This PR 
- uses UIOP functionality to scan all the paths in $XDG_DATA_DIRS first for `share/wayland` and `share/wayland-protocols` directories.
- Ensures `/usr/share` is still part of the search path to prevent breaking changes. But I haven't tested this on a mainstream distro.

###  Problem
1. The FFI generator only looks in `/usr/share` for the wayland spec directories. My linux distribution, GUIX, doesn't install development libraries in the same place that Fedora or Ubuntu might. 
2. If someone wants to work with different spec definitions than their distribution e.g. from a cloned `wayland-protocols` repo for local development, the FFI generator can't be targeted to its location.
3. I hope by using `$XDG_DATA_DIRS` this will be distribution-neutral

If there was a better way or already existing way to customize this that I've missed, I'd be happy to hear it and close.
 