### PR TITLE
Add binding for wl-display-flush

### DIFF
--- a/protocol.lisp
+++ b/protocol.lisp
@@ -2,7 +2,8 @@
   (:nicknames #:com.andrewsoutar.cl-wayland-client/protocol)
   (:use #:cl #:cffi #:com.andrewsoutar.cl-wayland-client/core)
   (:use-reexport #:com.andrewsoutar.cl-wayland-client.protocol/wayland)
-  (:export #:wl-display-connect #:wl-display-disconnect #:wl-display-dispatch #:wayland-destroy))
+  (:export #:wl-display-connect #:wl-display-disconnect #:wl-display-dispatch #:wayland-destroy
+           #:wl-display-flush))
 (cl:in-package #:com.andrewsoutar.cl-wayland-client/protocol)
 
 (defcfun (%wl-display-connect "wl_display_connect" :library libwayland-client) :pointer
@@ -29,4 +30,12 @@
   (let ((ret (%wl-display-dispatch (pointer display))))
     (if (minusp ret)
         (error "Error dispatching events")
+        ret)))
+
+(defcfun (%wl-display-flush "wl_display_flush") :int
+  (display :pointer))
+(defun wl-display-flush (display)
+  (let ((ret (%wl-display-flush (pointer display))))
+    (if (minusp ret)
+        (error "Error flushing display queue")
         ret)))


### PR DESCRIPTION
This `wl-display-flush` binding is missing since it's not part of the xml spec. I hope I'm adding it in the correct place.

